### PR TITLE
Installers remove phpMyAdmin setup folder

### DIFF
--- a/install/CentOS-6_4/install.sh
+++ b/install/CentOS-6_4/install.sh
@@ -273,6 +273,8 @@ chmod +s /etc/zpanel/panel/bin/zsudo
 chmod 644 /etc/zpanel/configs/phpmyadmin/config.inc.php
 sed -i "s|\$cfg\['blowfish_secret'\] \= 'SENTORA';|\$cfg\['blowfish_secret'\] \= '$phpmyadminsecret';|" /etc/zpanel/configs/phpmyadmin/config.inc.php
 ln -s /etc/zpanel/configs/phpmyadmin/config.inc.php /etc/zpanel/panel/etc/apps/phpmyadmin/config.inc.php
+# Remove phpMyAdmin's setup folder in case it was left behind
+rm -rf /etc/zpanel/panel/etc/apps/phpmyadmin/setup
 
 # MySQL specific installation tasks...
 service mysqld start

--- a/install/Ubuntu-12_04/install.sh
+++ b/install/Ubuntu-12_04/install.sh
@@ -256,6 +256,8 @@ chmod +s /etc/zpanel/panel/bin/zsudo
 chmod 644 /etc/zpanel/configs/phpmyadmin/config.inc.php
 sed -i "s|\$cfg\['blowfish_secret'\] \= 'SENTORA';|\$cfg\['blowfish_secret'\] \= '$phpmyadminsecret';|" /etc/zpanel/configs/phpmyadmin/config.inc.php
 ln -s /etc/zpanel/configs/phpmyadmin/config.inc.php /etc/zpanel/panel/etc/apps/phpmyadmin/config.inc.php
+# Remove phpMyAdmin's setup folder in case it was left behind
+rm -rf /etc/zpanel/panel/etc/apps/phpmyadmin/setup
 
 # MySQL specific installation tasks...
 service mysql start

--- a/upgrade/CentOS-6_4/10_1_1.sh
+++ b/upgrade/CentOS-6_4/10_1_1.sh
@@ -160,6 +160,9 @@ done
 #Disable php signature in headers
 sed -i "s|expose_php = On|expose_php = Off|" /etc/php.ini
 
+# Remove phpMyAdmin's setup folder in case it was left behind
+rm -rf /etc/zpanel/panel/etc/apps/phpmyadmin/setup
+
 # We ensure that the daemons are registered for automatic startup and are restarted for changes to take effect
 chkconfig httpd on
 chkconfig postfix on

--- a/upgrade/CentOS-6_4/upgrade.sh
+++ b/upgrade/CentOS-6_4/upgrade.sh
@@ -145,6 +145,9 @@ done
 #Disable php signature in headers
 sed -i "s|expose_php = On|expose_php = Off|" /etc/php.ini
 
+# Remove phpMyAdmin's setup folder in case it was left behind
+rm -rf /etc/zpanel/panel/etc/apps/phpmyadmin/setup
+
 # We ensure that the daemons are registered for automatic startup and are restarted for changes to take effect
 chkconfig httpd on
 chkconfig postfix on

--- a/upgrade/Ubuntu-12_04/10_1_1.sh
+++ b/upgrade/Ubuntu-12_04/10_1_1.sh
@@ -147,6 +147,9 @@ done
 # Disable PHP banner in apache server header
 sed -i "s|expose_php = On|expose_php = Off|" /etc/php5/apache2/php.ini
 
+# Remove phpMyAdmin's setup folder in case it was left behind
+rm -rf /etc/zpanel/panel/etc/apps/phpmyadmin/setup
+
 # We ensure that the daemons are registered for automatic startup and are restarted for changes to take effect
 service apache2 start
 service postfix restart

--- a/upgrade/Ubuntu-12_04/upgrade.sh
+++ b/upgrade/Ubuntu-12_04/upgrade.sh
@@ -133,6 +133,9 @@ done
 # Disable PHP banner in apache server header
 sed -i "s|expose_php = On|expose_php = Off|" /etc/php5/apache2/php.ini
 
+# Remove phpMyAdmin's setup folder in case it was left behind
+rm -rf /etc/zpanel/panel/etc/apps/phpmyadmin/setup
+
 # We ensure that the daemons are registered for automatic startup and are restarted for changes to take effect
 service apache2 start
 service postfix restart


### PR DESCRIPTION
The last version of ZPanel was retagged to include the phpMyAdmin setup folder (which can be used by anyone to muck up your install) so the upgrade scripts now delete it. Added it to the install scripts as well in case someone forgets to delete it when updating the repo.
