### PR TITLE
Update install.sh

### DIFF
--- a/install/CentOS-6_4/install.sh
+++ b/install/CentOS-6_4/install.sh
@@ -113,7 +113,7 @@ yum -y -q install tzdata wget &>/dev/null
 
 # Set some installation defaults/auto assignments
 fqdn=`/bin/hostname`
-publicip=`wget -qO- http://api.sentora.io/ip.txt`
+publicip=`wget -qO- http://api.sentora.org/ip.txt`
 
 echo "echo \$TZ > /etc/timezone" >> /usr/bin/tzselect
 


### PR DESCRIPTION
Corrected public-ip locator to use "sentora.org" as "sentora.io" is an invalid address at the moment.
This corrects several errors during and after installation
