### PR TITLE
Updated Vagrantfile to be used out-of-the-box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,94 +3,84 @@ PANEL_NAME = "zpanel"
 
 Vagrant.configure("2") do |config|
 
-	# mount install scripts
-	config.vm.synced_folder ".", "/root/sentora/install/",
-        	:owner =>"root", :group => "root", :mount_options => ['dmode=777,fmode=777']
-	# mount uninstall scripts
-	config.vm.synced_folder "uninstall/", "/root/sentora/uninstall/",
-        	:owner =>"root", :group => "root", :mount_options => ['dmode=777,fmode=777']
-	# mount upgrade scripts
-	#config.vm.synced_folder "upgrade/", "/root/sentora/upgrade/",
-        	#:owner =>"root", :group => "root", :mount_options => ['dmode=777,fmode=777']
-	
+  # mount install scripts
+  config.vm.synced_folder ".", "/root/sentora/install/",
+    :owner =>"root", :group => "root", :mount_options => ['dmode=777,fmode=777']
+  # mount uninstall scripts
+  config.vm.synced_folder "uninstall/", "/root/sentora/uninstall/",
+    :owner =>"root", :group => "root", :mount_options => ['dmode=777,fmode=777']
+  # mount upgrade scripts
+  #config.vm.synced_folder "upgrade/", "/root/sentora/upgrade/",
+    #:owner =>"root", :group => "root", :mount_options => ['dmode=777,fmode=777']
 
-    # Mount Development Folders
-    #ETC apache
-    config.vm.synced_folder "preconf/apache", "/etc/apache2/",
-            	:owner =>"root", :group => "root", :mount_options => ['dmode=777,fmode=777']
-    #ETC dovecot
-    config.vm.synced_folder "preconf/dovecot2", "/etc/dovecot/",
-               	:owner =>"root", :group => "root", :mount_options => ['dmode=777,fmode=777']
-    #ETC proftpd
-    config.vm.synced_folder "preconf/proftpd", "/etc/proftpd/",
-                :owner =>"root", :group => "root", :mount_options => ['dmode=777,fmode=777']
-    #ETC panel
-    #config.vm.synced_folder "preconf/#{PANEL_NAME}/", "/etc/#{PANEL_NAME}/",
-                #:owner =>"root", :group => "root", :mount_options => ['dmode=777,fmode=777']
 
-	config.vm.provider :virtualbox do |box|
-  		box.gui = false
-  		box.customize ["modifyvm", :id, "--memory", "512"]
-	end # box conf
-#####################################################################################
-# vagrant testing environments for sentora installer & upgrader
-	
-	# ubuntu 12.04 32bit # IP : 192.168.33.10
-	config.vm.define 'sentora_12.04ubuntu32' do |config|
-		config.vm.box = "ubuntu12_04-32"
-		config.vm.network :private_network, ip: "192.168.33.10"
-		config.vm.box_url = "http://cloud-images.ubuntu.com/vagrant/precise/current/precise-server-cloudimg-i386-vagrant-disk1.box"
-		config.vm.provider :virtualbox do |vb|
-			# custom virtual machine setup
-        		config.vm.hostname = "sentora-32-ubuntu"
-        		config.vm.boot_timeout = 800
-    		end
-	end # end define
+  # Mount Development Folders
+  #ETC apache
+  #config.vm.synced_folder "preconf/apache", "/etc/apache2/",
+    #:owner =>"root", :group => "root", :mount_options => ['dmode=777,fmode=777']
+  #ETC dovecot
+  #config.vm.synced_folder "preconf/dovecot2", "/etc/dovecot/",
+    #:owner =>"root", :group => "root", :mount_options => ['dmode=777,fmode=777']
+  #ETC proftpd
+  #config.vm.synced_folder "preconf/proftpd", "/etc/proftpd/",
+    #:owner =>"root", :group => "root", :mount_options => ['dmode=777,fmode=777']
+  #ETC panel
+  #config.vm.synced_folder "preconf/#{PANEL_NAME}/", "/etc/#{PANEL_NAME}/",
+    #:owner =>"root", :group => "root", :mount_options => ['dmode=777,fmode=777']
 
-	# ubuntu 12.04 64bit # IP : 192.168.33.11
-	config.vm.define 'sentora_12.04ubuntu64' do |config|
-		config.vm.box = "ubuntu12_04-64"
-		config.vm.network :private_network, ip: "192.168.33.11"
-		config.vm.box_url = "http://cloud-images.ubuntu.com/vagrant/precise/current/precise-server-cloudimg-amd64-vagrant-disk1.box"
-		config.vm.provider :virtualbox do |vb|
-			# custom virtual machine setup
-        		config.vm.hostname = "sentora-64-ubuntu"
-    		end
-	end # end define
+  config.vm.provider :virtualbox do |box|
+    box.gui = false
+    box.customize ["modifyvm", :id, "--memory", "512"]
+  end
 
-	# cento 6.4 32bit # IP : 192.168.33.12
-	config.vm.define 'sentora_6.4centos32' do |config|
-		config.vm.box = "centos6.4-32"
-		config.vm.network :private_network, ip: "192.168.33.12"
-		config.vm.box_url = "http://developer.nrel.gov/downloads/vagrant-boxes/CentOS-6.4-i386-v20131103.box"
-		config.vm.provider :virtualbox do |vb|
-			# custom virtual machine setup
-        		config.vm.hostname = "sentora-32-centos"
-    		end
-	end # end define
-	# cento 6.4 64bit # IP : 192.168.33.13
-	config.vm.define 'sentora_6.4centos64' do |config|
-		config.vm.box = "centos6.4-64"
-		config.vm.network :private_network, ip: "192.168.33.13"
-		config.vm.box_url = "http://developer.nrel.gov/downloads/vagrant-boxes/CentOS-6.4-x86_64-v20130731.box"
-		config.vm.provider :virtualbox do |vb|
-			# custom virtual machine setup
-        		config.vm.hostname = "sentora-64-centos"
-    		end
-	end # end define
-###################################################################
-## virtual os environments for installer on beta os's
-# ubuntu 14.04 64bit # IP : 192.168.33.15
-    config.vm.define 'sentora_14.04ubuntu64' do |config|
-        config.vm.box = "ubuntu14_04-64"
-        config.vm.network :private_network, ip: "192.168.33.15"
-        config.vm.box_url = "http://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
-        config.vm.provider :virtualbox do |vb|
-        	# custom virtual machine setup
-            config.vm.hostname = "sentora-64-ubuntu"
-        end
-    end # end config
+  #####################################################################################
+  # vagrant testing environments for sentora installer & upgrader
 
-end # Toplevel end
+  vms = {
+    "sentora_12.04ubuntu32" => {
+      :box  => "ubuntu12_04-32",
+      :url  => "http://cloud-images.ubuntu.com/vagrant/precise/current/precise-server-cloudimg-i386-vagrant-disk1.box",
+      :ip   => "192.168.33.10"
+    },
+    "sentora_12.04ubuntu64" => {
+      :box  => "ubuntu12_04-64",
+      :url  => "http://cloud-images.ubuntu.com/vagrant/precise/current/precise-server-cloudimg-amd64-vagrant-disk1.box",
+      :ip   => "192.168.33.11"
+    },
+    "sentora_6.4centos32" => {
+      :box  => "centos6.4-32",
+      :url  => "http://developer.nrel.gov/downloads/vagrant-boxes/CentOS-6.4-i386-v20131103.box",
+      :ip   => "192.168.33.13"
+    },
+    "sentora_6.4centos64" => {
+      :box  => "centos6.4-64",
+      :url  => "http://developer.nrel.gov/downloads/vagrant-boxes/CentOS-6.4-x86_64-v20130731.box",
+      :ip   => "192.168.33.14"
+    },
+    "sentora_14.04ubuntu64" => {
+      :box  => "ubuntu14_04-64",
+      :url  => "http://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box",
+      :ip   => "192.168.33.15"
+    },
+  }
+
+  vms.each do |hostname, v|
+    config.vm.define hostname do |conf|
+      conf.vm.box = v[:box]
+      conf.vm.box_url = v[:url]
+
+      conf.vm.network :private_network, ip: v[:ip]
+
+      conf.vm.boot_timeout = 800
+
+      conf.vm.provision "file",
+        source: "./install",
+        destination: "/tmp/"
+
+      conf.vm.provision "shell",
+        inline: "chmod +x /tmp/install/sentora_install.sh && /tmp/install/sentora_install.sh -d panel.domain.com -i #{v[:ip]} -t America/New_York && rm -r /tmp/install"
+    end
+  end
+end
 
 

--- a/install/sentora_install.sh
+++ b/install/sentora_install.sh
@@ -1054,7 +1054,6 @@ ln -s $PANEL_CONF/phpmyadmin/config.inc.php $PANEL_PATH/panel/etc/apps/phpmyadmi
 # Remove phpMyAdmin's setup folder in case it was left behind
 rm -rf $PANEL_PATH/panel/etc/apps/phpmyadmin/setup
 
-
 #--- Roundcube
 echo -e "\n-- Configuring Roundcube"
 


### PR DESCRIPTION
There were a number of paths that seemed out-dated or contrary to the purpose of a vm for testing the installer script (e.g. `#ETC panel`). With this Vagrantfile a simple `vagrant up` will get you a working box.
