### PR TITLE
set SOA Expire TTL from 1 day to 1 week

### DIFF
--- a/preconf/sentora-install/sql/sentora_core.sql
+++ b/preconf/sentora-install/sql/sentora_core.sql
@@ -647,7 +647,7 @@ insert  into `x_settings`(`so_id_pk`,`so_name_vc`,`so_cleanname_vc`,`so_value_tx
 (58,'zone_dir','Zone Directory','/etc/sentora/configs/bind/zones/',NULL,'Path to where DNS zone files are stored','DNS Config','true'),
 (59,'refresh_ttl','SOA Refesh TTL','21600',NULL,'Global refresh TTL.  Default = 21600 (6 hours)','DNS Config','true'),
 (60,'retry_ttl','SOA Retry TTL','3600',NULL,'Global retry TTL. Default = 3600 (1 hour)','DNS Config','true'),
-(61,'expire_ttl','SOA Expire TTL','86400',NULL,'Global expire TTL. Default = 86400 (1 day)','DNS Config','true'),
+(61,'expire_ttl','SOA Expire TTL','604800',NULL,'Global expire TTL. Default = 86400 (1 week)','DNS Config','true'),
 (62,'minimum_ttl','SOA Minimum TTL','86400',NULL,'Global minimum TTL. Default = 86400 (1 day)','DNS Config','true'),
 (63,'custom_ip','Allow Custom IP','true','true|false','Allow users to change IP settings in A records. If set to false, IP is locked to server IP setting in Sentora Config','DNS Config','true'),
 (64,'bind_dir','Path to BIND Root','',NULL,'Path to the root directory where BIND is installed.','DNS Config','true'),


### PR DESCRIPTION
inspectdns.com and intodns.com say its to short, i have set this value as sentora.org itself...