### PR TITLE
added support for Debian 7 and 8 and fixed sentora_postfix.vacation_notification creation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Our installation script currently support the following operating systems/distri
 
 * CentOS 6 and 7
 * Ubuntu 12.04 and 14.04
+* Debian 7 and 8
   
 Preliminary install information can be found here: [Sentora Documentation](http://docs.sentora.org/index.php?node=7)
  

--- a/preconf/sentora-install/sql/sentora_postfix.sql
+++ b/preconf/sentora-install/sql/sentora_postfix.sql
@@ -96,7 +96,7 @@ CREATE TABLE `vacation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Postfix Admin - Virtual Vacation';
 
 CREATE TABLE `vacation_notification` (
-  `on_vacation` varchar(255) CHARACTER SET latin1 NOT NULL,
+  `on_vacation` varchar(255) NOT NULL,
   `notified` varchar(255) CHARACTER SET latin1 NOT NULL,
   `notified_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`on_vacation`,`notified`),


### PR DESCRIPTION
1. The support for Debian 7 and 8 has been successfully tested on Debian 7.9 and 8.2.

2. The only error I got during my tests/installations was about the creation of the vacation_notification table in the sentora_postfix database. The issue was about **on_vacation** (in vacation_notification) set as latin1 while **email** (in vacation) is utf8 (they are connected via the FK).
It's fixed now.