### PR TITLE
Fixes for logrotate

### DIFF
--- a/sentora_install.sh
+++ b/sentora_install.sh
@@ -1335,10 +1335,9 @@ php -q $PANEL_PATH/panel/bin/daemon.php
 echo -e "\n-- Installing Logrotate"
 $PACKAGE_INSTALLER logrotate
 
-#	Create and link the configfiles 
-touch /etc/logrotate.d/Sentora-apache /etc/logrotate.d/Sentora-postifx /etc/logrotate.d/Sentora-dovecot
+#	Link the configfiles 
 ln -s $PANEL_CONF/logrotate/Sentora-apache /etc/logrotate.d/Sentora-apache
-ln -s $PANEL_CONF/logrotate/Sentora-postifx /etc/logrotate.d/Sentora-postifx
+ln -s $PANEL_CONF/logrotate/Sentora-proftpd /etc/logrotate.d/Sentora-proftpd
 ln -s $PANEL_CONF/logrotate/Sentora-dovecot /etc/logrotate.d/Sentora-dovecot
 
 #	Configure the postrotatesyntax for different OS


### PR DESCRIPTION
There are two fixes here

First, we should not be using touch to create the config files because it will not be possible to create the symbolic link thereafter, since the file already exists.
`ln: failed to create symbolic link 'Sentora-apache': File exists`

Secondly, there is no logrorate config file named Sentora-postifx in /preconf/logrotate, and given that the config file Sentora-proftpd is not linked, I'm assuming this is a typo and replaced
`ln -s $PANEL_CONF/logrotate/Sentora-postifx /etc/logrotate.d/Sentora-postifx`
by
`ln -s $PANEL_CONF/logrotate/Sentora-proftpd /etc/logrotate.d/Sentora-proftpd`

We are making use of the proftpd config file later in the install script so anyway we need that symbolic link which was missing.
