### PR TITLE
sentora_postfix_foreign_key_fix.sql

### DIFF
--- a/preconf/sentora-install/sql/sentora_postfix_foreign_key_fix.sql
+++ b/preconf/sentora-install/sql/sentora_postfix_foreign_key_fix.sql
@@ -1,0 +1,106 @@
+CREATE DATABASE `sentora_postfix` DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;
+
+USE `sentora_postfix`;
+
+CREATE USER postfix@localhost IDENTIFIED BY 'postfix';
+
+GRANT ALL PRIVILEGES ON sentora_postfix . * TO postfix@localhost;
+
+CREATE TABLE `admin` (
+  `username` varchar(255) NOT NULL,
+  `password` varchar(255) NOT NULL,
+  `created` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `modified` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `active` tinyint(1) NOT NULL DEFAULT '1',
+  PRIMARY KEY (`username`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Postfix Admin - Virtual Admins';
+
+CREATE TABLE `alias` (
+  `address` varchar(255) NOT NULL,
+  `goto` text NOT NULL,
+  `domain` varchar(255) NOT NULL,
+  `created` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `modified` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `active` tinyint(1) NOT NULL DEFAULT '1',
+  PRIMARY KEY (`address`),
+  KEY `domain` (`domain`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Postfix Admin - Virtual Aliases';
+
+CREATE TABLE `alias_domain` (
+  `alias_domain` varchar(255) NOT NULL,
+  `target_domain` varchar(255) NOT NULL,
+  `created` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `modified` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `active` tinyint(1) NOT NULL DEFAULT '1',
+  PRIMARY KEY (`alias_domain`),
+  KEY `active` (`active`),
+  KEY `target_domain` (`target_domain`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Postfix Admin - Domain Aliases';
+
+CREATE TABLE `config` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(20) NOT NULL DEFAULT '',
+  `value` varchar(20) NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `name` (`name`)
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COMMENT='PostfixAdmin settings';
+
+CREATE TABLE `domain` (
+  `domain` varchar(255) NOT NULL,
+  `description` varchar(255) CHARACTER SET utf8 NOT NULL,
+  `aliases` int(10) NOT NULL DEFAULT '0',
+  `mailboxes` int(10) NOT NULL DEFAULT '0',
+  `maxquota` bigint(20) NOT NULL DEFAULT '0',
+  `quota` bigint(20) NOT NULL DEFAULT '0',
+  `transport` varchar(255) NOT NULL,
+  `backupmx` tinyint(1) NOT NULL DEFAULT '0',
+  `created` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `modified` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `active` tinyint(1) NOT NULL DEFAULT '1',
+  PRIMARY KEY (`domain`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Postfix Admin - Virtual Domains';
+
+
+CREATE TABLE `mailbox` (
+  `username` varchar(255) NOT NULL,
+  `password` varchar(255) NOT NULL,
+  `name` varchar(255) CHARACTER SET utf8 NOT NULL,
+  `maildir` varchar(255) NOT NULL,
+  `quota` bigint(20) NOT NULL DEFAULT '0',
+  `local_part` varchar(255) NOT NULL,
+  `domain` varchar(255) NOT NULL,
+  `created` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `modified` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `active` tinyint(1) NOT NULL DEFAULT '1',
+  PRIMARY KEY (`username`),
+  KEY `domain` (`domain`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Postfix Admin - Virtual Mailboxes';
+
+CREATE TABLE `quota2` (
+  `username` varchar(100) NOT NULL,
+  `bytes` bigint(20) NOT NULL DEFAULT '0',
+  `messages` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`username`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `vacation` (
+  `email` varchar(255) NOT NULL,
+  `subject` varchar(255) CHARACTER SET utf8 NOT NULL,
+  `body` text CHARACTER SET utf8 NOT NULL,
+  `cache` text NOT NULL,
+  `domain` varchar(255) NOT NULL,
+  `created` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `active` tinyint(1) NOT NULL DEFAULT '1',
+  PRIMARY KEY (`email`),
+  KEY `email` (`email`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Postfix Admin - Virtual Vacation';
+
+CREATE TABLE `vacation_notification` (
+  `on_vacation` varchar(255) NOT NULL,
+  `notified` varchar(255) CHARACTER SET latin1 NOT NULL,
+  `notified_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`on_vacation`,`notified`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Postfix Admin - Virtual Vacation Notifications';
+
+ALTER TABLE `vacation_notification`
+  ADD CONSTRAINT `vacation_notification_pkey` FOREIGN KEY (`on_vacation`) REFERENCES `vacation` (`email`) ON DELETE CASCADE;


### PR DESCRIPTION
## Fix the 
## ERROR 1005 (HY000) at line 98: Can't create table `sentora_postfix`.`vacation_no                                                                                                                                                             tification` (errno: 150 "Foreign key constraint is incorrectly formed")

seen on somes postfix installation under CentOS 7 / Fedora for MariaDB
