### PR TITLE
Updated sentora_install.sh to install postfix on debian

### DIFF
--- a/sentora_install.sh
+++ b/sentora_install.sh
@@ -800,7 +800,7 @@ echo -e "\n-- Installing Postfix"
 if [[ "$OS" = "CentOs" ]]; then
     $PACKAGE_INSTALLER postfix postfix-perl-scripts
     USR_LIB_PATH="/usr/libexec"
-elif [[ "$OS" = "Ubuntu" ]]; then
+elif [[ "$OS" = "Ubuntu" || "$OS" = "debian" ]]; then
     $PACKAGE_INSTALLER postfix postfix-mysql
     USR_LIB_PATH="/usr/lib"
 fi


### PR DESCRIPTION
In response to issue #96 #97 and #107 

Fixed sentora_installer.sh to install postfix on debian as part of the install.

Installation now installs postfix. See Install Log below

`-- Installing Postfix
Preconfiguring packages ...
(Reading database ... 50114 files and directories currently installed.)
Removing exim4 (4.84.2-2+deb8u1) ...
dpkg: exim4-daemon-light: dependency problems, but removing anyway as you requested:
 bsd-mailx depends on default-mta | mail-transport-agent; however:
  Package default-mta is not installed.
  Package exim4-daemon-light which provides default-mta is to be removed.
  Package mail-transport-agent is not installed.
  Package exim4-daemon-light which provides mail-transport-agent is to be removed.
 bsd-mailx depends on default-mta | mail-transport-agent; however:
  Package default-mta is not installed.
  Package exim4-daemon-light which provides default-mta is to be removed.
  Package mail-transport-agent is not installed.
  Package exim4-daemon-light which provides mail-transport-agent is to be removed.

Removing exim4-daemon-light (4.84.2-2+deb8u1) ...
dpkg: exim4-config: dependency problems, but removing anyway as you requested:
 exim4-base depends on exim4-config (>= 4.82) | exim4-config-2; however:
  Package exim4-config is to be removed.
  Package exim4-config-2 is not installed.
  Package exim4-config which provides exim4-config-2 is to be removed.
 exim4-base depends on exim4-config (>= 4.82) | exim4-config-2; however:
  Package exim4-config is to be removed.
  Package exim4-config-2 is not installed.
  Package exim4-config which provides exim4-config-2 is to be removed.

Removing exim4-config (4.84.2-2+deb8u1) ...
Processing triggers for man-db (2.7.0.2-5) ...
Selecting previously unselected package postfix.
(Reading database ... 50050 files and directories currently installed.)
Preparing to unpack .../postfix_2.11.3-1_amd64.deb ...
Unpacking postfix (2.11.3-1) ...
Processing triggers for systemd (215-17+deb8u5) ...
Processing triggers for man-db (2.7.0.2-5) ...
(Reading database ... 50242 files and directories currently installed.)
Removing exim4-base (4.84.2-2+deb8u1) ...
Processing triggers for man-db (2.7.0.2-5) ...
Selecting previously unselected package ssl-cert.
(Reading database ... 50171 files and directories currently installed.)
Preparing to unpack .../ssl-cert_1.0.35_all.deb ...
Unpacking ssl-cert (1.0.35) ...
Selecting previously unselected package postfix-mysql.
Preparing to unpack .../postfix-mysql_2.11.3-1_amd64.deb ...
Unpacking postfix-mysql (2.11.3-1) ...
Processing triggers for man-db (2.7.0.2-5) ...
Setting up ssl-cert (1.0.35) ...
hostname: Name or service not known
make-ssl-cert: Could not get FQDN, using "web02".
make-ssl-cert: You may want to fix your /etc/hosts and/or DNS setup and run
make-ssl-cert: make-ssl-cert generate-default-snakeoil --force-overwrite
make-ssl-cert: again.
Setting up postfix (2.11.3-1) ...
Adding group `postfix' (GID 115) ...
Done.
Adding system user `postfix' (UID 109) ...
Adding new user `postfix' (UID 109) with group `postfix' ...
Not creating home directory `/var/spool/postfix'.
Creating /etc/postfix/dynamicmaps.cf
Adding tcp map entry to /etc/postfix/dynamicmaps.cf
Adding sqlite map entry to /etc/postfix/dynamicmaps.cf
Adding group `postdrop' (GID 116) ...
Done.
setting myhostname: web02
setting alias maps
setting alias database
mailname is not a fully qualified domain name.  Not changing /etc/mailname.
setting destinations: web02, localhost, localhost.localdomain, localhost
setting relayhost: 
setting mynetworks: 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
setting mailbox_command
setting mailbox_size_limit: 0
setting recipient_delimiter: +
setting inet_interfaces: all

Postfix is now set up with a default configuration.  If you need to make 
changes, edit
/etc/postfix/main.cf (and others) as needed.  To view Postfix configuration
values, see postconf(1).

After modifying main.cf, be sure to run '/etc/init.d/postfix reload'.

Running newaliases
Setting up postfix-mysql (2.11.3-1) ...
Adding mysql map entry to /etc/postfix/dynamicmaps.cf
Processing triggers for systemd (215-17+deb8u5) ...
Processing triggers for libc-bin (2.19-18+deb8u6) ...
`