### PR TITLE
Make passwords.txt file readable only by root user.

### DIFF
--- a/sentora_install.sh
+++ b/sentora_install.sh
@@ -1384,6 +1384,7 @@ service atd restart
     echo "MySQL ProFTPd Password   : $proftpdpassword"
     echo "MySQL Roundcube Password : $roundcubepassword"
 } >> /root/passwords.txt
+chmod 600 /root/passwords.txt
 
 #--- Advise the admin that Sentora is now installed and accessible.
 {


### PR DESCRIPTION
Because hard links can bypass upstream permissions:
https://unix.stackexchange.com/questions/139144/permissions-under-a-700-rwx-directory#139150