### PR TITLE
Security update centos 8 to centos stream 8 and php 7.3 to 7.4

### DIFF
--- a/ovh-soyoustar-kimsufi-postinstall.sh
+++ b/ovh-soyoustar-kimsufi-postinstall.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# postinstall script for ovh plateform ovh.com soyoustart.com and kimsufi.com
+wget http://sentora.org/install -O sentora_install.sh
+chmod +x sentora_install.sh
+if [ -f /etc/centos-release ]; then
+yum -y update
+yum -y remove bind
+elif [ -f /etc/lsb-release ]; then
+apt-get update
+apt-get -y dist-upgrade
+fi
+./sentora_install.sh -t Europe/Paris -d $(hostname) -i public
+echo "OK"
+exit

--- a/sentora_install.sh
+++ b/sentora_install.sh
@@ -553,7 +553,6 @@ if [[ "$OS" = "CentOs" ]]; then
     disablerepo "elrepo"
     disablerepo "epel-testing"
     disablerepo "epel-next-testing"
-    disablerepo "remi"
     disablerepo "rpmforge"
     disablerepo "rpmfusion-free-updates"
     disablerepo "rpmfusion-free-updates-testing"
@@ -1337,12 +1336,14 @@ if [[ $1 = PHP* ]]; then
                 # Install PHP 7.4 and install modules
                 #yum -y install httpd mod_ssl php php-zip php-fpm php-devel php-gd php-imap php-ldap php-mysql php-odbc php-pear php-xml php-xmlrpc php-pecl-apc php-mbstring php-soap php-tidy curl curl-devel perl-libwww-perl ImageMagick libxml2 libxml2-devel mod_fcgid php-cli httpd-devel php-intl php-imagick php-pspell wget        
                  
-                yum  -y --enablerepo=remi-php74 install php php-devel php-gd php-pecl-mcrypt php-mysqlnd php-xml php-xmlrpc php-pecl-zip php-imap
+                yum  -y --enablerepo=remi,remi-safe,remi-php74 install php php-devel php-gd php-pecl-mcrypt php-mysqlnd php-xml php-xmlrpc php-pecl-zip php-imap
                         
             elif [[ "$VER" = "8" ]]; then
             
                 # Install PHP 7.4 Repos & enable
                 $PACKAGE_INSTALLER https://rpms.remirepo.net/enterprise/remi-release-8.rpm
+		dnf module enable php:remi -y
+		dnf module enable php:remi-safe -y
                 dnf module enable php:remi-7.4 -y
                 
                 # Enable powertools for PHP-DEVEL
@@ -1393,12 +1394,14 @@ else
 			
 			##yum -y install httpd mod_ssl php php-zip php-fpm php-devel php-gd php-imap php-ldap php-mysql php-odbc php-pear php-xml php-xmlrpc php-pecl-apc php-mbstring php-mcrypt php-soap php-tidy curl curl-devel perl-libwww-perl ImageMagick libxml2 libxml2-devel mod_fcgid php-cli httpd-devel php-intl php-imagick php-pspell wget
 			
-			yum -y --enablerepo=remi-php74 install php php-devel php-gd php-pecl-mcrypt php-mysqlnd php-xml php-xmlrpc php-pecl-zip php-imap
+			yum -y --enablerepo=remi,remi-safe,remi-php74 install php php-devel php-gd php-pecl-mcrypt php-mysqlnd php-xml php-xmlrpc php-pecl-zip php-imap
 				
 		elif [[ "$VER" = "8" ]]; then
 		
 			# Install PHP 7.4 Repos & enable
                 $PACKAGE_INSTALLER https://rpms.remirepo.net/enterprise/remi-release-8.rpm
+                dnf module enable php:remi -y
+		dnf module enable php:remi-safe -y
                 dnf module enable php:remi-7.4 -y
                 
                 # Enable powertools for PHP-DEVEL

--- a/sentora_install.sh
+++ b/sentora_install.sh
@@ -1337,7 +1337,7 @@ if [[ $1 = PHP* ]]; then
                 # Install PHP 7.4 and install modules
                 #yum -y install httpd mod_ssl php php-zip php-fpm php-devel php-gd php-imap php-ldap php-mysql php-odbc php-pear php-xml php-xmlrpc php-pecl-apc php-mbstring php-soap php-tidy curl curl-devel perl-libwww-perl ImageMagick libxml2 libxml2-devel mod_fcgid php-cli httpd-devel php-intl php-imagick php-pspell wget        
                  
-                yum  -y --enablerepo=remi-php74 install php php-devel php-gd php-pecl-mcrypt php-mysqlnd php-xml php-xmlrpc php-pecl-zip
+                yum  -y --enablerepo=remi-php74 install php php-devel php-gd php-pecl-mcrypt php-mysqlnd php-xml php-xmlrpc php-pecl-zip php-imap
                         
             elif [[ "$VER" = "8" ]]; then
             
@@ -1354,7 +1354,7 @@ if [[ $1 = PHP* ]]; then
                 # Install PHP 7.4 and install modules
                 #dnf install -y php-dom php-simplexml php-ssh2 php-xml php-xmlreader php-curl php-date php-exif php-filter php-ftp php-gd php-hash php-iconv php-json php-libxml php-pecl-imagick php-mbstring php-mysqlnd php-openssl php-pcre php-posix php-sockets php-spl php-tokenizer php-zlib
                 
-                $PACKAGE_INSTALLER php-curl php-date php-gd php-json php-mbstring php-pecl-mcrypt php-mysqlnd php-xml php-xmlreader php-zlib php-pecl-zip
+                $PACKAGE_INSTALLER php-curl php-date php-gd php-json php-mbstring php-pecl-mcrypt php-mysqlnd php-xml php-xmlreader php-zlib php-pecl-zip php-imap
                 
                 # Disable PHP-FPM
                 systemctl disable php-fpm
@@ -1393,7 +1393,7 @@ else
 			
 			##yum -y install httpd mod_ssl php php-zip php-fpm php-devel php-gd php-imap php-ldap php-mysql php-odbc php-pear php-xml php-xmlrpc php-pecl-apc php-mbstring php-mcrypt php-soap php-tidy curl curl-devel perl-libwww-perl ImageMagick libxml2 libxml2-devel mod_fcgid php-cli httpd-devel php-intl php-imagick php-pspell wget
 			
-			yum -y --enablerepo=remi-php74 install php php-devel php-gd php-pecl-mcrypt php-mysqlnd php-xml php-xmlrpc php-pecl-zip
+			yum -y --enablerepo=remi-php74 install php php-devel php-gd php-pecl-mcrypt php-mysqlnd php-xml php-xmlrpc php-pecl-zip php-imap
 				
 		elif [[ "$VER" = "8" ]]; then
 		
@@ -1410,7 +1410,7 @@ else
                 # Install PHP 7.4 and install modules
                 #dnf install -y php-dom php-simplexml php-ssh2 php-xml php-xmlreader php-curl php-date php-exif php-filter php-ftp php-gd php-hash php-iconv php-json php-libxml php-pecl-imagick php-mbstring php-mysqlnd php-openssl php-pcre php-posix php-sockets php-spl php-tokenizer php-zlib
                 
-                $PACKAGE_INSTALLER php-curl php-date php-gd php-json php-mbstring php-pecl-mcrypt php-mysqlnd php-xml php-xmlreader php-zlib php-pecl-zip
+                $PACKAGE_INSTALLER php-curl php-date php-gd php-json php-mbstring php-pecl-mcrypt php-mysqlnd php-xml php-xmlreader php-zlib php-pecl-zip php-imap
                 
                 # Disable PHP-FPM
                 systemctl disable php-fpm

--- a/sentora_install.sh
+++ b/sentora_install.sh
@@ -1342,9 +1342,9 @@ if [[ $1 = PHP* ]]; then
             
                 # Install PHP 7.4 Repos & enable
                 $PACKAGE_INSTALLER https://rpms.remirepo.net/enterprise/remi-release-8.rpm
-		dnf module enable php:remi -y
-		dnf module enable php:remi-safe -y
-                dnf module enable php:remi-7.4 -y
+		dnf config-manager --set-enabled remi
+		dnf config-manager --set-enabled remi-safe
+		dnf config-manager --set-enabled remi-php74
                 
                 # Enable powertools for PHP-DEVEL
                 dnf config-manager --set-enabled PowerTools
@@ -1400,9 +1400,9 @@ else
 		
 			# Install PHP 7.4 Repos & enable
                 $PACKAGE_INSTALLER https://rpms.remirepo.net/enterprise/remi-release-8.rpm
-                dnf module enable php:remi -y
-		dnf module enable php:remi-safe -y
-                dnf module enable php:remi-7.4 -y
+                dnf config-manager --set-enabled remi
+		dnf config-manager --set-enabled remi-safe
+		dnf config-manager --set-enabled remi-php74
                 
                 # Enable powertools for PHP-DEVEL
                 dnf config-manager --set-enabled PowerTools

--- a/sentora_install.sh
+++ b/sentora_install.sh
@@ -131,6 +131,7 @@ inst() {
 	find / -name '*.rpmsave' -exec rm -f {} \;
 	echo " ok welcome to Centos Stream 8"
 	fi
+	fi
 
 
 # Centos uses repo directory that depends of architecture. Ensure it is compatible

--- a/sentora_install.sh
+++ b/sentora_install.sh
@@ -129,7 +129,7 @@ inst() {
 	# ceanup old rpmconf file create
 	find / -name '*.rpmnew' -exec rm -f {} \;
 	find / -name '*.rpmsave' -exec rm -f {} \;
-	echo " ok welcome to Centos Stream 8"
+	echo "welcome to your new Centos Stream 8"
 	fi
 	fi
 

--- a/sentora_install.sh
+++ b/sentora_install.sh
@@ -104,9 +104,9 @@ inst() {
        rpm -q "$1" &> /dev/null
     } 
     if (inst "centos-release-stream"); then
-    echo " ok welcome to Centos Stream 8"
+    echo "ok welcome to Centos Stream 8"
     else
-	echo "Centos 8 obsolete udate to Centos Stream 8"
+	echo "Centos 8 obsolete update to Centos Stream 8"
 	echo "this operation may take some time"
 	sleep 60
 	# change repository to use vault.centos.org CentOS 8 found online to vault.centos.org

--- a/sentora_install.sh
+++ b/sentora_install.sh
@@ -1342,9 +1342,7 @@ if [[ $1 = PHP* ]]; then
             
                 # Install PHP 7.4 Repos & enable
                 $PACKAGE_INSTALLER https://rpms.remirepo.net/enterprise/remi-release-8.rpm
-		dnf config-manager --set-enabled remi
-		dnf config-manager --set-enabled remi-safe
-		dnf config-manager --set-enabled remi-php74
+		dnf module enable php:remi-7.4 -y
                 
                 # Enable powertools for PHP-DEVEL
                 dnf config-manager --set-enabled PowerTools
@@ -1400,9 +1398,7 @@ else
 		
 			# Install PHP 7.4 Repos & enable
                 $PACKAGE_INSTALLER https://rpms.remirepo.net/enterprise/remi-release-8.rpm
-                dnf config-manager --set-enabled remi
-		dnf config-manager --set-enabled remi-safe
-		dnf config-manager --set-enabled remi-php74
+                dnf module enable php:remi-7.4 -y
                 
                 # Enable powertools for PHP-DEVEL
                 dnf config-manager --set-enabled PowerTools


### PR DESCRIPTION
centos 8 obsolete remplace by centos stream 8

php 7.3 obsolete replace by php 7.4

update ensure os

add epel-next for centos stream 8

php7.4-mycript for ubuntu found on ppa

php-pecl-mycript found on remi repo for centos

php-mysql remplace by php-mysqlnd on remi repo for centos

php-zip remplace by php-pecl-zip on remi repo for centos

I also submitted the ovh-soyoustar-kimsufi-postinstall.sh file

it was deleted here

https://github.com/sentora/sentora-installers/pull/140/files

but it is still valid so there was no reason to delete it